### PR TITLE
Make constraint returned from addToView discardable

### DIFF
--- a/Restraint/Restraint.swift
+++ b/Restraint/Restraint.swift
@@ -91,7 +91,7 @@ public struct Restraint {
     )
   }
 
-  public func addToView(_ view: UIView) -> NSLayoutConstraint {
+  @discardableResult public func addToView(_ view: UIView) -> NSLayoutConstraint {
     let constraint = self.constraint()
 
     if let leftView = leftItem as? UIView {


### PR DESCRIPTION
In Swift 2, unused return values were silently ignored. This changed in Swift 3, so now `addToView(_)` will cause a buildtime warning unless you use the returned constraint. This commit adds `@discardableResult` to said method.